### PR TITLE
Add preview tag to true

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "version": "0.1.1",
   "license": "MIT",
   "publisher": "redhat",
+  "preview": true,
   "repository": {
     "type": "git",
     "url": "https://github.com/talamer/vscode-knative.git"


### PR DESCRIPTION
This change is necessary as all the extensions in VSCode Marketplace supported by Red Hat should be in `Preview` state.