### PR TITLE
Hide some commands from command palette

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-knative",
-  "version": "0.3.0",
+  "version": "0.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -163,7 +163,20 @@
       }
     ],
     "menus": {
-      "commandPalette": [],
+      "commandPalette": [
+        {
+          "command": "service.explorer.delete",
+          "when": "false"
+        },
+        {
+          "command": "knative.service.open-in-browser",
+          "when": "false"
+        },
+        {
+          "command": "service.explorer.openFile",
+          "when": "false"
+        }
+      ],
       "view/item/context": [
         {
           "command": "knative.service.open-in-browser",


### PR DESCRIPTION
Hides commands that require a knative resource to be selected from the command palette. These commands throw an error if used outside the Knative view.