### PR TITLE
Revisions can have multiple traffic items

### DIFF
--- a/src/knative/revision.ts
+++ b/src/knative/revision.ts
@@ -7,13 +7,13 @@ import { URL } from 'url';
 import { KnativeItem } from './knativeItem';
 
 export class Revision extends KnativeItem {
-  constructor(public name: string, public service: string, public details?: Items, public traffic?: Traffic | null) {
+  constructor(public name: string, public service: string, public details?: Items, public traffic?: Traffic[] | null) {
     super();
   }
 
   status: boolean;
 
-  static toRevision(value: Items, revisionTraffic: Traffic): Revision {
+  static toRevision(value: Items, revisionTraffic: Traffic[]): Revision {
     const revision = new Revision(value.metadata.name, value.metadata.ownerReferences[0].name, value, revisionTraffic);
     return revision;
   }

--- a/src/tree/knativeTreeItem.ts
+++ b/src/tree/knativeTreeItem.ts
@@ -79,7 +79,12 @@ export class KnativeTreeItem extends TreeItem {
     if (parent && parent.contextValue === 'service') {
       const rev: Revision = item as Revision;
       if (rev && rev.traffic) {
-        this.label = `${this.label} (${rev.traffic.percent}%)`;
+        const percentTraffic = rev.traffic.find((val) => {
+          return val.percent;
+        });
+        if (percentTraffic) {
+          this.label = `${this.label} (${percentTraffic.percent}%)`;
+        }
       }
     }
   }

--- a/src/tree/serviceDataProvider.ts
+++ b/src/tree/serviceDataProvider.ts
@@ -95,11 +95,8 @@ export class ServiceDataProvider implements TreeDataProvider<KnativeTreeItem> {
     const revisions: Revision[] = this.ksvc.addRevisions(
       loadItems(result).map((value: Items) => {
         // get the revision name, check it against the list of traffic from the parent, then pass in the traffic if found
-        const revisionTraffic: Traffic = traffic.find((val): boolean => {
-          if (value.metadata.name === val.revisionName) {
-            return true;
-          }
-          return false;
+        const revisionTraffic: Traffic[] = traffic.filter((val): boolean => {
+          return value.metadata.name === val.revisionName;
         });
         return Revision.toRevision(value, revisionTraffic);
       }),


### PR DESCRIPTION
Allows revision objects to be associated with multiple traffic objects.