### PR TITLE
Enable Open In Browser for tagged revisions

### DIFF
--- a/package.json
+++ b/package.json
@@ -183,17 +183,12 @@
       "view/item/context": [
         {
           "command": "knative.service.open-in-browser",
-          "when": "view == knativeProjectExplorerServices && viewItem == service",
+          "when": "view == knativeProjectExplorerServices && viewItem == service || viewItem == revision.tagged",
           "group": "c1"
         },
         {
           "command": "service.explorer.delete",
-          "when": "view == knativeProjectExplorerServices && viewItem == service",
-          "group": "c2"
-        },
-        {
-          "command": "service.explorer.delete",
-          "when": "view == knativeProjectExplorerServices && viewItem == revision",
+          "when": "view == knativeProjectExplorerServices && viewItem == service || viewItem =~ /revision.*/g",
           "group": "c2"
         }
       ],

--- a/src/kn/config.ts
+++ b/src/kn/config.ts
@@ -13,6 +13,7 @@ export const enum Kind {
 
 export enum ContextType {
   REVISION = 'revision',
+  REVISION_TAGGED = 'revision.tagged',
   SERVICE = 'service',
   LOGIN_REQUIRED = 'login_required',
 }

--- a/src/tree/knativeTreeItem.ts
+++ b/src/tree/knativeTreeItem.ts
@@ -20,6 +20,12 @@ const CONTEXT_DATA = {
     description: '',
     getChildren: (): undefined[] => [],
   },
+  'revision.tagged': {
+    icon: 'REV.svg',
+    tooltip: 'Revision: {name}',
+    description: '',
+    getChildren: (): undefined[] => [],
+  },
   service: {
     icon: 'SVC.svg',
     tooltip: 'Service: {name}',

--- a/src/tree/serviceDataProvider.ts
+++ b/src/tree/serviceDataProvider.ts
@@ -109,11 +109,16 @@ export class ServiceDataProvider implements TreeDataProvider<KnativeTreeItem> {
 
     // Create the Revision tree item for each one found.
     const revisionTreeObjects: KnativeTreeItem[] = revisions.map<KnativeTreeItem>((value) => {
+      let context = ContextType.REVISION;
+      if (value.traffic && value.traffic.find((val) => val.tag)) {
+        context = ContextType.REVISION_TAGGED;
+      }
+
       const obj: KnativeTreeItem = new KnativeTreeItem(
         parentService,
         value,
         value.name,
-        ContextType.REVISION,
+        context,
         TreeItemCollapsibleState.None,
         null,
         null,

--- a/test/knative/knativeServices.test.ts
+++ b/test/knative/knativeServices.test.ts
@@ -72,6 +72,16 @@ suite('Knative Services', () => {
       assert.equals({ revision, service }, returnedServiceRevision);
     });
   });
+  suite('Check Traffic', () => {
+    test('should a revision with 2 traffics one tagged', () => {
+      const returnedRevision = ksvc.findRevision('greeter-btrnq-1');
+      assert.equals(revision, returnedRevision);
+      chai.assert.exists(revision.traffic);
+      chai.assert.equal(revision.traffic.length, 2);
+      chai.assert.equal(revision.traffic[0].percent, 100);
+      chai.assert.equal(revision.traffic[1].tag, 'old');
+    });
+  });
   suite('Finding Service and Revision indexes', () => {
     test('should return an object with both service and revision using the revision name', () => {
       const returnedServiceRevision = ksvc.findRevisionAndServiceIndex('greeter-btrnq-1');

--- a/test/tree/singleServiceServiceList.json
+++ b/test/tree/singleServiceServiceList.json
@@ -132,7 +132,14 @@
                   "latestRevision": true,
                   "percent": 100,
                   "revisionName": "greeter-btrnq-1"
-              }
+              },
+              {
+                "tag": "old",
+                "revisionName": "greeter-btrnq-1",
+                "latestRevision": false,
+                "percent": 0,
+                "url": "http://old-greeter-a-serverles-example.apps.devcluster.openshift.com"
+            }
           ],
           "url": "http://greeter-a-serverles-example.apps.devcluster.openshift.com"
       }


### PR DESCRIPTION
This adds a new context type of `revision.tagged`. Adds the `Open In Browser` command to this context type.  This feature allows us to open directly any tagged version of the service.